### PR TITLE
INTELSDK-2061 Migrate latest docs to markdown

### DIFF
--- a/docs/Android/android-install.md
+++ b/docs/Android/android-install.md
@@ -6,7 +6,7 @@ hide:
   - toc
 ---
 
-## Standard Integration¶
+## Standard Integration
 
 To integrate the Android Intelligence SDK into your application, you will need to pull the SDK artifacts from our Github Maven repository. This is a public repository, however currently Github credentials are still required to be provided.
 
@@ -45,6 +45,45 @@ dependencies {
 
 !!!Note
     For more information on using Github Maven Gradle Registry, please visit: [Working with the Gradle registry - GitHub Docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry)
+
+
+## SDK Integration through Local Repository
+
+The IntelligenceSDK and it’s dependencies will now be hosted in a Maven folder structure 
+found in the Release section of our public Github Page: https://github.com/euc-releases/ws1-intelligencesdk-sdk-android
+
+After downloading and unzipping the following repository folder, you can now reference and pull the
+IntelligenceSDK using the following structure:
+
+```groovy
+   
+   // App level Build.Gradle Configuration (Groovy)
+   
+   repositories {
+       maven {
+           url uri("/PATH/TO/FOLDER/ws1-intelligence-sdk-repository")
+       }
+       mavenCentral()
+       google()
+   }
+   
+   android {
+      packagingOptions {
+           pickFirst '**/libc++_shared.so'
+           pickFirst '**/libcrypto.1.0.2.so'
+           pickFirst '**/libssl.1.0.2.so'
+       }
+   }
+   
+   def ws1IntelSdkVersion = "24.6.1"
+   
+   dependencies {
+       // Declare a dependency on the Intelligence SDK
+       implementation "com.vmware.ws1:ws1intelligencesdk:$ws1IntelSdkVersion"
+   }
+```
+
+
 
 ## Integration Alongside Workspace ONE SDK
 

--- a/docs/Android/android-integrate-ws1sdk.md
+++ b/docs/Android/android-integrate-ws1sdk.md
@@ -6,9 +6,9 @@ hide:
   - toc
 ---
 
-A new Public API added to provide UEM attributes to the IntelligenceSDK’s DEX feature:
+A new Public API has been added to provide UEM attributes to the IntelligenceSDK’s DEX feature:
 
-- This API takes an information provider interface which allows users to create getter methods for each available data attribute: UEM Device UDID, UEM Serial Number, UEM Username.
+- This API takes an information provider interface which allows users to create getter methods for each available data attribute: **UEM Device UDID**, **UEM Serial Number**, **UEM Username**.
 
 Android UEMInfo Interface
 ```JAVA
@@ -16,14 +16,17 @@ Android UEMInfo Interface
 * Interface for providing UEM Information to our DEX
 */
 interface UemInfo {
+
 /**
  * Returns the UEM Device UDID as a String
  */
 fun getUemDeviceUDID(): String?
+
 /**
  * Returns the UEM Serial Number as a String
  */
 fun getUemSerialNumber(): String?
+
 /**
  * Returns the UEM Username as a String
  */

--- a/docs/Android/crittercism.md
+++ b/docs/Android/crittercism.md
@@ -20,7 +20,7 @@ Initialize Workspace ONE Intelligence SDK. After calling this method, crashes an
 public static synchronized void initialize (Context context, String appID)
 ```
 
-**Paramters**
+**Parameters**
 
 |   |   |
 | --- | --- |
@@ -37,7 +37,7 @@ Initialize Workspace ONE Intelligence SDK. After calling this method, crashes an
 public static synchronized void initialize (Context context, String appID, CrittercismConfig config)
 ```
 
-**Paramters**
+**Parameters**
 
 |   |   |
 | --- | --- |
@@ -84,7 +84,7 @@ Workspace ONE Intelligence SDK will automatically insert a breadcrumb marked ses
 public static void leaveBreadcrumb (String breadcrumb)
 ```
 
-**Paramters**
+**Parameters**
 
 |   |   |
 | --- | --- |
@@ -104,7 +104,7 @@ Breadcrumbs are limited to 140 characters, and only the most recent 100 are kept
 public static void leaveUserflowSpecificBreadcrumb(@NonNull final String userflowName, @NonNull final String text)
 ```
 
-**Paramters**
+**Parameters**
 
 |   |   |
 | --- | --- |
@@ -135,7 +135,7 @@ We limit logging handled exceptions to once per minute. If you’ve logged an ex
 public static void logHandledException (Throwable t)
 ```
 
-**Paramters**
+**Parameters**
 
 |   |   |
 | --- | --- |
@@ -176,7 +176,7 @@ public static void logNetworkRequest(String method,
                                      Exception error)
 ```
 
-**Paramters**
+**Parameters**
 
 |   |   |
 | --- | --- |
@@ -267,7 +267,7 @@ If the app uses this method to provide a recent location to the SDK, then Networ
 
 You have the option of updating location information with data given by android.location.LocationManager.NETWORK_PROVIDER or android.location.LocationManager.GPS_PROVIDER. This allows more accurate data to be sent to the server.
 
-As explained in the Android Developer Guide, in order to receive location updates from the network or GPS provider, your AndroidManifest.xml` file must include either the ``ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION permissions.
+As explained in the Android Developer Guide, in order to receive location updates from the network or GPS provider, your `AndroidManifest.xml` file must include either the `ACCESS_COARSE_LOCATION` or `ACCESS_FINE_LOCATION` permissions.
 
 **Declaration**
 
@@ -275,9 +275,10 @@ As explained in the Android Developer Guide, in order to receive location update
 public static void updateLocation (Location curLocation)
 ```
 
-location
+**Parameters**
 
-Location of the user / device
+| --- | --- |
+| location | Location of the user / device |
 
 Introduced in Android SDK 4.2.0
 
@@ -518,7 +519,16 @@ This capability was introduced in Android SDK 5.3.0
 
 ## Opt In Status
 
-Workspace ONE Intelligence SDK provides an opt-out setting that disables all reporting to Workspace ONE Intelligence. This allows developers to implement code that asks end users whether they want to opt out of Workspace ONE Intelligence. For an introduction, see Opt Out of Workspace ONE Intelligence.
+Workspace ONE Intelligence SDK provides an opt-in settings API that can 
+enable or disable reporting for the Workspace ONE Intelligence features and 
+can enable or disable reporting for the DEX feature. 
+Each feature can be controlled individually. 
+Note that each feature can have different default settings.
+
+This allows developers to implement code that allows end users to decide 
+which reporting features they want to enable for Workspace ONE Intelligence.
+
+For an introduction, see Opt Out of Workspace ONE Intelligence.
 
 ### getOptInStatus (telemetryType)
 

--- a/docs/Android/dex-telemetry-integration.md
+++ b/docs/Android/dex-telemetry-integration.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: Telemetry Feature Integration
+hide:
+  #- navigation
+  - toc
+---
+
+## Export Data Collected by Telemetry Features
+
+Users are now able to export data collected from the Telemetry Features they have Opted-Into. Use the following API to get Feature, Event, and Export formatted specific data in an Asynchronous fashion!
+
+!!!Note
+    This feature is available only if the app has opted-in to the DEX feature. See [Enabling DEX](crittercism.md#dex-telemetry-opt-in)
+
+Telemetry Export API
+```java
+	
+   /**
+   * Interface for handling Telemetry Feature exported data.
+   */
+   interface TelemetryExportHandler {
+      /**
+      * Callback when data export has completed.
+      * @param data String which will contain exported Telemetry Feature data,
+      * null if error occurs.
+      */
+      fun onDataExport(data: String?)
+   }
+   /**
+    * Asynchronously Export Data collected through enabled Telemetry Features.
+    * @param feature Telemetry Feature to query data for.
+    * @param eventType Type of Telemetry Event data to query for: Attributes, Events, or All.
+    * @param exportType Format of the data exported, currently offering JSON support only.
+    * @param dataHandler Interface called when data is ready to be exported.
+    */
+   public static void exportTelemetryFeatureData( @NonNull TelemetryFeature feature,
+                                                  @NonNull TelemetryEventType eventType,
+                                                  @NonNull TelemetryExportType exportType,
+                                                  @NonNull TelemetryExportHandler dataHandler) 
+```
+
+Telemetry Export Example
+```java
+
+   // Implement the TelemetryExportHandler Interface to reach exported data asynchronously.
+   val dataHandler = object:TelemetryExportHandler { 
+    // Callback method for export. Data parameter will either have formatted Telemetry
+    // data or be null if an issue occurs. 
+    override fun onDataExport(data: String?) {
+        Log.d(TAG, "Here is my exported data: ${data ?: "An issue has occurred."}")
+      } 
+   }
+   
+   Crittercism.exportTelemetryFeatureData(
+            TelemetryFeature.All, // Query data from all enabled features.
+            TelemetryEventType.ALL, // Returns values for all data types.
+            TelemetryExportType.JSON, // Format to export data in.
+            dataHandler) // Exported data handler callback.
+```
+

--- a/docs/Android/index.md
+++ b/docs/Android/index.md
@@ -10,8 +10,6 @@ hide:
 
 This topic describes how to use Workspace ONE Intelligence with Android apps. This guide assumes you have an Workspace ONE Intelligence account set up with a valid app ID.
 
-The Apple SDKs may be downloaded [here](../index.md#sdk-downloads).
-
 ## Release Notes
 
 Release Notes can be viewed [here](release-notes.md).
@@ -31,13 +29,14 @@ Release Notes can be viewed [here](release-notes.md).
 
 ## SDK References
 
-Import com.crittercism.app package to use the Workspace ONE Intelligence SDK.
+Import `com.crittercism.app` package to use the Workspace ONE Intelligence SDK.
 
 - [Crittercism](crittercism.md)
 - [CrittercismConfig](crittercism-config.md)
 - [CrittercismCallback](crittercism-callback.md)
 - [CrashData](crash-data.md)
 - [NetworkInstrumentation](network-instrumentation.md)
+- [Telemetry Feature Integration](dex-telemetry-integration.md)
 
 ## Features
 

--- a/docs/Android/release-notes.md
+++ b/docs/Android/release-notes.md
@@ -6,12 +6,70 @@ hide:
   - toc
 ---
 
-Updated on 31/21/2024
+Updated on 8/9/2024
 
-What's in the Release Notes¶
-Workspace ONE SDK for Android Release Notes describe the new features and enhancements in each release. This page contains a summary of the new capabilities, issues that have been resolved, and known issues that have been reported in each release. The Workspace ONE SDK for Android is a set of tools that incorporates Workspace ONE UEM functionality into custom-built, for Android applications.
+What's in the Release Notes
 
-## Workspace ONE SDK 24.6.0 for Android - July 2024
+Workspace ONE Intelligence SDK for Android Release Notes describe the new features and enhancements in each release. This page contains a summary of the new capabilities, issues that have been resolved, and known issues that have been reported in each release. 
+
+## Workspace ONE Intelligence SDK 24.6.1 for Android - August 9, 2024
+
+### Minimum Requirements
+
+- Android 5.0 or later
+- API Level 21 or later
+- Workspace ONE UEM Console 2109 or later
+- Android Studio with the Gradle Android Build System (Gradle) 8.2.2 or later
+
+### New Features
+
+- SDK Integration through Local Repository
+
+The IntelligenceSDK and it’s dependencies will now be hosted in a Maven folder structure 
+found in the Release section of our public Github Page: https://github.com/euc-releases/ws1-intelligencesdk-sdk-android
+
+After downloading and unzipping the following repository folder, you can now reference and pull the
+IntelligenceSDK using the following structure:
+
+```groovy
+   
+   // App level Build.Gradle Configuration (Groovy)
+   
+   repositories {
+       maven {
+           url uri("/PATH/TO/FOLDER/ws1-intelligence-sdk-repository")
+       }
+       mavenCentral()
+       google()
+   }
+   
+   android {
+      packagingOptions {
+           pickFirst '**/libc++_shared.so'
+           pickFirst '**/libcrypto.1.0.2.so'
+           pickFirst '**/libssl.1.0.2.so'
+       }
+   }
+   
+   def ws1IntelSdkVersion = "24.6.1"
+   
+   dependencies {
+       // Declare a dependency on the Intelligence SDK
+       implementation "com.vmware.ws1:ws1intelligencesdk:$ws1IntelSdkVersion"
+   }
+```
+
+### Resolved Issues
+
+- Protobuf Dependency upgraded from older `protobuf-java` implementation to `protobuf-javalite`.
+   - This allows for greater compatibility within projects that import other dependencies that rely on Protobuf, such as Google’s Firestore.
+
+### Known Issues
+
+none
+
+
+## Workspace ONE Intelligence SDK 24.6.0 for Android - July 2024
 
 ### Minimum Requirements
 
@@ -87,7 +145,7 @@ none
 
 none
 
-## Workspace ONE SDK 24.3.1 for Android - March 2024
+## Workspace ONE Intelligence SDK 24.3.1 for Android - March 2024
 
 ### Minimum Requirements
 
@@ -111,7 +169,7 @@ none
   - `onReceivedHttpError(WebView, WebResourceRequest, WebResourceResponse)`
   - `onReceivedError(WebView, WebResourceRequest, WebResourceError)`
 
-## Workspace ONE SDK 24.3.0 for Android - March 2024
+## Workspace ONE Intelligence SDK 24.3.0 for Android - March 2024
 
 ### Minimum Requirements
 

--- a/docs/Apple/index.md
+++ b/docs/Apple/index.md
@@ -10,8 +10,6 @@ hide:
 
 This guide assumes you have an Workspace ONE Intelligence account set up with a valid app ID.
 
-The Apple SDKs may be downloaded [here](../index.md#sdk-downloads).
-
 ## Release Notes
 
 Release Notes can be viewed [here](release-notes.md).

--- a/docs/Apple/release-notes.md
+++ b/docs/Apple/release-notes.md
@@ -8,7 +8,7 @@ hide:
 
 Updated August 15, 2024
 
-## What's in the Release Notes¶
+## What's in the Release Notes
 
 These release notes describe the new features and enhancements in each release of Workspace ONE IntelligenceSDK for iOS. (Sometimes called "IntelligenceSDK".) This page contains a summary of the new capabilities, issues that have been resolved, and known issues that have been reported in each release. Workspace ONE IntelligenceSDK for iOS is a set of tools allow iOS apps to send telemetry data to the Workspace ONE Intelligence backend. 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 # Project Information
-site_name: WS1 SDK Intelligence
+site_name: WS1 Intelligence SDK
 site_url: https://euc-dev.github.io/ws1-sdk-intelligence
 site_author: Phil Helmling
 site_description: Submodule for developer.omnissa.com


### PR DESCRIPTION
mkdocs.yml
- corrected site_name from 'WS1 SDK Intelligence' (which confuses with "WS1 SDK", aka AirWatch) to 'WS1 Intelligence SDK' which is more like the actual name

android-install.md
- removed odd '¶' character
- added section 'SDK Integration through Local Repository' from the old documentation

android-integrate-ws1sdk.md
- tweaked some wording and added bold formatting to some words that were bold in the old documentation
- added some blank lines

crittercism.md
- corrected many misspellings of 'Parameters'
- added some inline code markers to match the docs versions in the old docs repositories
- restored Location parameters table
- copied in most recent content for 'Opt In Status' from the 'include' file in old documentation

dex-telemetry-integration.md
- added new file to match the new file in the old documentation

Android/index.md
- removed old line saying "The Apple SDKs may be downloaded here"
- added some inline quote marks
- added reference to new file "dex-telemetry-integration.md" in section "SDK References"

Android/release-notes.md
- fixed strange 'Updated on' date  "31/21/2024"
- removed odd '¶' character from "What's in the Release Notes¶"
- added release notes for Android 24.6.1 to match the old documentation
- fixed some references from "Workspace ONE SDK" to "Workspace ONE Intelligence SDK"

Apple/index.md
- removed old line saying "The Apple SDKs may be downloaded here"

Apple/release-notes.md
- removed odd '¶' character from "What's in the Release Notes¶"