### PR TITLE
INTELSDK-2648 Documentation improvement for battery monitoring feature

### DIFF
--- a/docs/Apple/ws1intelligence.md
+++ b/docs/Apple/ws1intelligence.md
@@ -655,10 +655,7 @@ class func setOptInStatusFor(type: WS1TelemetryType, andStatus: Bool)
 
 !!!Note 
 
-	When you set OptIn for DEX to true, the SDK will set the UIDevice property `isBatteryMonitoringEnabled` to true to allow reporting battery metrics. The app should not set `isBatteryMonitoringEnabled` to false after this point.
-	If the app disables 'BatteryData' with the [setPrivacyConfiguration](ws1intelligence.md/#setprivacyconfigurationprivacyconfig-telemetryfeature) API, the SDK will set `isBatteryMonitoringEnabled` to false.
-	
-
+	When you set OptIn for DEX to true, the SDK will set the UIDevice property `isBatteryMonitoringEnabled` to true to allow reporting battery metrics. The app should not set `isBatteryMonitoringEnabled` to false after this point.	
 
 
 ### getOptOutStatus (deprecated)

--- a/docs/Apple/ws1intelligence.md
+++ b/docs/Apple/ws1intelligence.md
@@ -653,6 +653,11 @@ class func setOptInStatusFor(type: WS1TelemetryType, andStatus: Bool)
 | type   | WS1TelemetryType enum entry, `Application` or `DEX` |
 | status | set to YES to enable Omnissa Intelligence SDK |
 
+!!!Note 
+
+	When you set OptIn for DEX to true, the SDK will set the UIDevice property `isBatteryMonitoringEnabled` to true to allow reporting battery metrics. The app should not set `isBatteryMonitoringEnabled` to false after this point.
+	If the app disables 'BatteryData' with the [setPrivacyConfiguration](ws1intelligence.md/#setprivacyconfigurationprivacyconfig-telemetryfeature) API, the SDK will set `isBatteryMonitoringEnabled` to false.
+	
 
 
 


### PR DESCRIPTION
ws1intelligence.md

Add note that the developer of the app should not change the setting for UIDevice property `isBatteryMonitoringEnabled` after setting OptIn for DEX to true or the battery monitoring feature will not work.