### PR TITLE
INTELSDK-2682 Documentation changes 24.11.0

### DIFF
--- a/docs/Android/release-notes.md
+++ b/docs/Android/release-notes.md
@@ -36,7 +36,8 @@ none
 
 ### Known Issues
 
-none
+- Instrumented URLConnection Classes network request elapsed time inaccurate. 
+- Application Lifecycle Breadcrumbs for “Foreground”, “Background” events may be inaccurate.
 
 
 ## Omnissa Intelligence SDK 24.8.0 for Android - September 16, 2024

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,8 @@ Omnissa provides each Software Development Kit (the “Software”) to you subje
 
 For additional information, please visit the [Omnissa Legal Center](https://www.omnissa.com/legal-center/).
 
-The SDK is provided as either a [Android Package](https://github.com/orgs/euc-releases/packages?repo_name=ws1-intelligencesdk-sdk-android), [Android Release](https://github.com/euc-releases/ws1-intelligencesdk-sdk-android/releases), [iOS Package](https://github.com/orgs/euc-releases/packages?repo_name=ws1-intelligencesdk-sdk-ios), [iOS Release](https://github.com/euc-releases/ws1-intelligencesdk-sdk-ios/releases). Please download the software from the appropriate location.
+The SDK can be downloaded as either an [Android Package](https://github.com/orgs/euc-releases/packages?repo_name=ws1-intelligencesdk-sdk-android) or as an [iOS Release](https://github.com/euc-releases/ws1-intelligencesdk-sdk-ios/releases). Please download the software from the appropriate location.
+
 
 ## Developer Guides
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,7 +147,6 @@ markdown_extensions:
 # Navigation
 nav:
   - index.md
-  - SDK Core Capabilities: ../../dev-centre/ws1/core-capabilities/
   - Omnissa Intelligence SDK for Android: 
     - ./Android/index.md
     - Installing the Android SDK: ./Android/android-install.md


### PR DESCRIPTION
mkdocs.yml
- removed "Core Capabilities" link that leads into the WS1 SDK documentation (AirWatchSDK)

index.md
- removed the download links that did not apply to the platforms

release-notes.md
- added 'Known Issues' lines that were missing from the original notes in Confluence