### PR TITLE
INTELSDK-2978 workaround for SPM conflict with WS1SDK

### DIFF
--- a/docs/Apple/release-notes.md
+++ b/docs/Apple/release-notes.md
@@ -34,7 +34,10 @@ These release notes describe the new features and enhancements in each release o
 
 ### Known Issues
 
-none
+- The Swift Package Manager (SPM) files for WS1IntelligenceSDK 25.4.0 and 25.4.1 have a conflict with the SPM files for Omnissa’s WS1SDK (aka AirWatchSDK) version 25.04.0 and 25.04.1 when both are used in the same app.
+	- Workaround: You can use SPM for WS1SDK, and manually download WS1IntelligenceSDK.xcframework. 
+      - Download the desired zip from Releases · euc-releases/ws1-intelligencesdk-sdk-ios and unzip it
+      - manually install the xcframework folder into your iOS project/workspace.
 
 
 ## Omnissa IntelligenceSDK for iOS 25.4.0 Release - June 2025
@@ -82,7 +85,10 @@ none
 
 ### Known Issues
 
-none
+- The Swift Package Manager (SPM) files for WS1IntelligenceSDK 25.4.0 and 25.4.1 have a conflict with the SPM files for Omnissa’s WS1SDK (aka AirWatchSDK) version 25.04.0 and 25.04.1 when both are used in the same app.
+	- Workaround: You can use SPM for WS1SDK, and manually download WS1IntelligenceSDK.xcframework. 
+      - Download the desired zip from Releases · euc-releases/ws1-intelligencesdk-sdk-ios and unzip it
+      - manually install the xcframework folder into your iOS project/workspace.
 
 
 ## Omnissa IntelligenceSDK for iOS 25.1.3 Release - June 2025


### PR DESCRIPTION
release-notes.md
- added workaround for 'Known Issues' item: Add WS1SDK with SPM. Add WS1IntelligenceSDK manually.